### PR TITLE
Build the images before creating any clusters

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -97,7 +97,7 @@ preload-images: images
 	done
 
 # [deploy] deploys Submariner on KIND clusters
-deploy: clusters preload-images
+deploy: images clusters preload-images
 	$(SCRIPTS_DIR)/deploy.sh $(DEPLOY_ARGS)
 
 # [e2e] executes the project's end to end testing on the deployed KIND clusters


### PR DESCRIPTION
This makes building lighther on the VMs, since the memory
pressure is much lower, and cache will work much better.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>